### PR TITLE
Early mount EFS

### DIFF
--- a/arch/arm64/boot/dts/exynos8890.dtsi
+++ b/arch/arm64/boot/dts/exynos8890.dtsi
@@ -131,6 +131,14 @@
 					fsmgr_flags = "wait";
 					status = "ok";
 				};
+                                efs {
+                                        compatible = "android,efs";
+                                        dev = "/dev/block/platform/155a0000.ufs/by-name/EFS";
+                                        type = "ext4";
+                                        mnt_flags = "noatime,nosuid,nodev,noauto_da_alloc,discard,journal_async_commit,data=ordered,errors=panic";
+                                        fsmgr_flags = "wait,check";
+                                        status = "ok";
+                                }; 
 			};
 		};
 	};


### PR DESCRIPTION
needed so system can load /efs/factory.prop and detect dsds/ss devices